### PR TITLE
Update for export_csv() for Statistics Page

### DIFF
--- a/url_shortner_server/shortner/link_stats_view.py
+++ b/url_shortner_server/shortner/link_stats_view.py
@@ -11,15 +11,17 @@ from shortner.models import Link, LinkAccess
 class LinkStatsView(View):
     """StatsView is responsible for displaying and exporting link statistics"""
 
-    def get(self, request, special_code):
+    def get(self, request: HttpRequest, special_code=None):
         """Handles GET requests to display link statistics or export CSV"""
         username = request.session.get("username", "")
         if not username:
             return redirect("signin")
 
+        if request.path.endswith("/export-stats-csv/"):
+            return self.export_stats_csv(request, special_code)
+
         # Get the link object by special_code and ensure it belongs to the current user
         link = get_object_or_404(Link, special_code=special_code, username=username)
-        print(link.long_url)
 
         # Fetch all accesses for this link
         accesses = LinkAccess.objects.filter(link=link).order_by('-accessed_at')
@@ -32,3 +34,46 @@ class LinkStatsView(View):
 
         return render(request, "homepages/linkstats.html", context=context)
 
+    def export_stats_csv(self, request: HttpRequest, special_code):
+        """Exports link statistics as CSV with date and time in filename"""
+        username = request.session.get("username", "")
+        if not username:
+            return redirect("signin")
+
+        # Get the link object by special_code and ensure it belongs to the current user
+        link = get_object_or_404(Link, special_code=special_code, username=username)
+
+        # Fetch all accesses for this link
+        accesses = LinkAccess.objects.filter(link=link).order_by('-accessed_at')
+
+        # Generate filename with current date and time
+        current_datetime = datetime.now().strftime("%Y%m%d_%H%M%S")
+        filename = f"link_statistics_{current_datetime}.csv"
+
+        response = HttpResponse(content_type="text/csv")
+        response["Content-Disposition"] = f'attachment; filename="{filename}"'
+
+        writer = csv.writer(response)
+        writer.writerow(["Access Time", "Device Type", "Browser", "City", "Region", "Country"])
+
+        for access in accesses:
+
+            access_time = access.accessed_at if access else "Unknown"
+            device_type = access.device_type if access else "Unknown"
+            browser = access.browser if access else "Unknown"
+            city = access.city if access else "Unknown"
+            region = access.region if access else "Unknown"
+            country = access.country if access else "Unknown"
+
+            writer.writerow(
+                [
+                    access_time,
+                    device_type,
+                    browser,
+                    city,
+                    region,
+                    country,
+                ]
+            )
+
+        return response

--- a/url_shortner_server/shortner/stats_view.py
+++ b/url_shortner_server/shortner/stats_view.py
@@ -61,21 +61,15 @@ class StatsView(View):
         response["Content-Disposition"] = f'attachment; filename="{filename}"'
 
         writer = csv.writer(response)
-        writer.writerow(["Long URL", "Short URL", "CTR", "Device Type", "Browser"])
+        writer.writerow(["Long URL", "Short URL", "CTR"])
 
         for link_obj in list_of_links:
-            latest_access = LinkAccess.objects.filter(link=link_obj).order_by('-accessed_at').first()
-
-            device_type = latest_access.device_type if latest_access else "Unknown"
-            browser = latest_access.browser if latest_access else "Unknown"
 
             writer.writerow(
                 [
                     link_obj.long_url,
                     request.build_absolute_uri("/") + "stub/" + link_obj.stub,
                     link_obj.ctr,
-                    device_type,
-                    browser
                 ]
             )
 

--- a/url_shortner_server/shortner/stats_view.py
+++ b/url_shortner_server/shortner/stats_view.py
@@ -55,7 +55,7 @@ class StatsView(View):
 
         # Generate filename with current date and time
         current_datetime = datetime.now().strftime("%Y%m%d_%H%M%S")
-        filename = f"link_statistics_{current_datetime}.csv"
+        filename = f"all_url_statistics_{current_datetime}.csv"
 
         response = HttpResponse(content_type="text/csv")
         response["Content-Disposition"] = f'attachment; filename="{filename}"'

--- a/url_shortner_server/shortner/tests/test_views.py
+++ b/url_shortner_server/shortner/tests/test_views.py
@@ -341,7 +341,7 @@ class TestViews(TestCase):
 
         content_disposition = response["Content-Disposition"]
         self.assertTrue(
-            content_disposition.startswith('attachment; filename="link_statistics_')
+            content_disposition.startswith('attachment; filename="all_url_statistics_')
         )
 
     def test_stats_view_ctr_update(self):

--- a/url_shortner_server/shortner/tests/test_views.py
+++ b/url_shortner_server/shortner/tests/test_views.py
@@ -150,7 +150,7 @@ class TestViews(TestCase):
         self.assertEqual(response["Content-Type"], "text/csv")
         self.assertTrue(
             response["Content-Disposition"].startswith(
-                'attachment; filename="link_statistics_'
+                'attachment; filename="all_url_statistics_'
             )
         )
 

--- a/url_shortner_server/shortner/tests/test_views.py
+++ b/url_shortner_server/shortner/tests/test_views.py
@@ -182,7 +182,7 @@ class TestViews(TestCase):
         rows = list(csv_reader)
 
         self.assertEqual(len(rows), 2)
-        self.assertEqual(rows[0], ["Long URL", "Short URL", "CTR", "Device Type", "Browser"])
+        self.assertEqual(rows[0], ["Long URL", "Short URL", "CTR"])
 
     def test_export_csv_multiple_links(self):
         self.client.post(

--- a/url_shortner_server/templates/homepages/linkstats.html
+++ b/url_shortner_server/templates/homepages/linkstats.html
@@ -286,9 +286,9 @@
                         </div>
                     </div>
                     <div class="primary-btn text-center">
-                        <form action="{% url 'export_csv' %}" method="get" style="display: inline;">
+                        <form action="{% url 'export_stats_csv' special_code=link.special_code %}" method="get" style="display: inline;">
                             {% csrf_token %}
-                            <button type="submit" class="btn btn-primary btn-lg">Export URLs</button>
+                            <button type="submit" class="btn btn-primary btn-lg">Export Stats CSV</button>
                         </form>
                     </div>
                 </div>

--- a/url_shortner_server/templates/homepages/urlstats.html
+++ b/url_shortner_server/templates/homepages/urlstats.html
@@ -304,7 +304,7 @@
                     <div class="primary-btn text-center">
                         <form action="{% url 'export_csv' %}" method="get" style="display: inline;">
                             {% csrf_token %}
-                            <button type="submit" class="btn btn-primary btn-lg">Export URLs</button>
+                            <button type="submit" class="btn btn-primary btn-lg">Export URLs CSV</button>
                         </form>
                     </div>
                 </div>

--- a/url_shortner_server/url_shortner_server/urls.py
+++ b/url_shortner_server/url_shortner_server/urls.py
@@ -61,4 +61,5 @@ urlpatterns = [
     path("vt_stats", VirusTotalStatsView.as_view(), name="vt_stats"),
     path("vt_stats_full", vt_stats_full, name="vt_stats_full"),
     path('link/stats/<uuid:special_code>/', LinkStatsView.as_view(), name='link_stats'),
+    path('stats/<uuid:special_code>/export-stats-csv/', LinkStatsView.as_view(), name='export_stats_csv')
 ]


### PR DESCRIPTION
Now two CSV files can be downloaded. One CSV file has stats for all the URL files. The other CSV file has stats for a particular shortened URL.

![Screenshot 2024-11-15 202357](https://github.com/user-attachments/assets/a5a58388-c3e5-490c-9d22-a20b14ba9423)
 